### PR TITLE
add requires to samba

### DIFF
--- a/gnome-control-center.spec
+++ b/gnome-control-center.spec
@@ -9,7 +9,7 @@
 Summary:	GNOME control center
 Name:		gnome-control-center
 Version:	40.0
-Release:	1
+Release:	2
 License:	GPLv2+
 Group:		Graphical desktop/GNOME
 Url:		http://www.gnome.org/softwaremap/projects/control-center/
@@ -90,6 +90,7 @@ Requires:	glib-networking
 Requires:	gsettings-desktop-schemas
 Requires:	networkmanager-applet
 Requires:	networkmanager
+Requires: samba-libs
 
 Requires(post,postun):	shared-mime-info desktop-file-utils
 


### PR DESCRIPTION
at clean gnome installation, samba-libs is not installed by default and thanks to this we can't run default gnome control conter due missing some samba .so